### PR TITLE
Upgrade components: Gradle 9.1.0, Build Tools 36.1.0, NDK 29.0.142068…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Version of tools:
 # In Code
-ARG GRADLE_VERSION=8.11.1
+ARG GRADLE_VERSION=9.1.0
 ARG ANDROID_API_LEVEL=36
 # https://developer.android.com/studio/releases/build-tools
-ARG ANDROID_BUILD_TOOLS_LEVEL=36.0.0
+ARG ANDROID_BUILD_TOOLS_LEVEL=36.1.0
 # https://developer.android.com/ndk/downloads
-ARG ANDROID_NDK_VERSION=29.0.13113456
+ARG ANDROID_NDK_VERSION=29.0.14206865
 # https://developer.android.com/studio/
-ARG ANDROID_CMD_LINE_TOOLS=linux-13114758_latest
+ARG ANDROID_CMD_LINE_TOOLS=linux-14742923_latest
 # https://developer.android.com/build/jdks
 ARG OPEN_JDK=openjdk-17-jdk
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Android Lightweight is a very lightweight docker image for Android, which contains only the latest version of Android Libraries:
 
-- Ubuntu 25.04
+- Ubuntu 25.10
 - OpenJDK 17
-- Gradle 8.11.1
+- Gradle 9.1.0
 - Android API 36
-- Android Build Tools 36.0.0
-- Android NDK (Side by side) 29.0.13113456
-- Command line tools linux-13114758_latest.zip
+- Android Build Tools 36.1.0
+- Android NDK (Side by side) 29.0.14206865
+- Command line tools linux-14742923_latest.zip
 - Accepted all licenses
 
 The how-to article for creating this from scratch is published here: [How to build a Lightweight Docker Container for Android Build](https://github.com/Simplatex/android-lightweight/wiki/How-to-build-a-Lightweight-Docker-Container-for-Android-Build)


### PR DESCRIPTION
Upgrade Android build components and base image
• Update Ubuntu to 25.10
• Upgrade Gradle to 9.1.0
• Upgrade Android API Level to 36
• Upgrade Android Build Tools to 36.1.0
• Upgrade Android NDK to 29.0.14206865
• Upgrade Android Command Line Tools to linux-14742923_latest
• Update README.md to reflect these changes