### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Simplatex/android-lightweight/security/code-scanning/1](https://github.com/Simplatex/android-lightweight/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the individual job so that the `GITHUB_TOKEN` has only the minimal required permissions. Since this workflow only needs to read the repository contents (for checkout) and does all external publishing to Docker Hub using secrets, it does not need any write permissions on the GitHub repo.

The best minimal fix here is to add a workflow-level `permissions` block that applies to all jobs and restricts the token to read-only repository contents. Concretely, in `.github/workflows/main.yml`, between `name: CI` (line 3) and the `on:` block (line 6), add:

```yaml
permissions:
  contents: read
```

This documents the intended access and prevents the `GITHUB_TOKEN` from having unnecessary write access, without changing any of the existing steps or functionality. No additional imports or methods are needed because this is purely a configuration change within the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
